### PR TITLE
Decrease Docker Image Size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Basis-Image
-FROM node:18-alpine
+FROM node:18-alpine AS builder
 
 # Arbeitsverzeichnis
 WORKDIR /app
@@ -18,6 +18,21 @@ RUN npx prisma generate
 # Next.js Build
 RUN npm run build
 
+# Build artefacts are located in .next/standalone
+# https://nextjs.org/docs/app/api-reference/config/next-config-js/output
+
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/prisma ./prisma
+COPY public ./public
+
+ENV PORT=8000
+ENV HOSTNAME=0.0.0.0
+
 # Port und Startbefehl
 EXPOSE 8000
-CMD ["npm", "start"]
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+    output: "standalone"
 };
 
 export default nextConfig;


### PR DESCRIPTION
Changed next.js build output to `standalone`. From the docs (https://nextjs.org/docs/app/api-reference/config/next-config-js/output), this produces a `server.js`, which can be executed using `node server.js`, whilst including only the necessary files. Additionally, since no CDN is (currently) being used to serve the static files, these are also copied into the image as per the documentation.  

Further added a multi-staged docker build process which only copies standalone files from the next.js build output. 

Total image size is reduced from ~2.1GB to ~330MB. 


`npx prisma [...]` has **not been tested**. This should be tested locally on a development db, before merging. 